### PR TITLE
remove all blank lines at the beginning of a frame

### DIFF
--- a/StompKit/StompKit.m
+++ b/StompKit/StompKit.m
@@ -119,8 +119,13 @@
 	NSString *msg = [[NSString alloc] initWithData:strData encoding:NSUTF8StringEncoding];
     LogDebug(@"<<< %@", msg);
     NSMutableArray *contents = (NSMutableArray *)[[msg componentsSeparatedByString:kLineFeed] mutableCopy];
-	if([[contents objectAtIndex:0] isEqual:@""]) {
-		[contents removeObjectAtIndex:0];
+    for (int i = 0; i < contents.count; i++) {
+        if ([[contents objectAtIndex:0] isEqual:@""]) {
+            [contents removeObjectAtIndex:0];
+        }
+        else {
+            break;
+        }
 	}
 	NSString *command = [[contents objectAtIndex:0] copy];
 	NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
I'm using StompKit on iOS 6.1 with ActiveMQ 5.9.0 on the server side. When a message is sent from the broker after some seconds of inactivity, there are several blank lines before the line which contains the frame code.
Because the StompKit code only removes one blank line, StompKit wasn't able to extract the frame code from the data. This commit fixed that for me.
