### PR TITLE
Added WebSocket Support

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,6 +2,8 @@ xcodeproj 'StompKit.xcodeproj'
 
 platform :ios, '5.0'
 
+
+pod 'SocketRocket', '0.3.1-beta2'
 pod 'CocoaAsyncSocket', '7.3.2'
 
 target 'StompKitTests', :exclusive => true do

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ STOMPClient *client = [[STOMPClient alloc] initWithHost:@"localhost"
 [client connectWithLogin:@"mylogin"
                 passcode:@"mypassword"
        completionHandler:^(STOMPFrame *_, NSError *error) {
-            if (err) {
+            if (error) {
                 NSLog(@"%@", error);
                 return;
             }
@@ -66,7 +66,7 @@ STOMPClient *client = [[STOMPClient alloc] initWithHost:@"localhost"
 [client connectWithLogin:@"mylogin"
                 passcode:@"mypassword"
        completionHandler:^(STOMPFrame *_, NSError *error) {
-            if (err) {
+            if (error) {
                 NSLog(@"%@", error);
                 return;
             }

--- a/StompKit.podspec
+++ b/StompKit.podspec
@@ -11,4 +11,5 @@ Pod::Spec.new do |s|
   s.public_header_files = 'StompKit/StompKit.h'
   s.requires_arc = true
   s.dependency 'CocoaAsyncSocket', '7.3.4'
+  s.dependency 'SocketRocket', '0.3.1-beta2'
 end

--- a/StompKit.podspec
+++ b/StompKit.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/mobile-web-messaging/StompKit.git', :tag => "#{s.version}" }
   s.platform     = :ios, 5.0
   s.source_files = 'StompKit/*.{h,m}'
-  s.public_header_files = 'StompKit/StompKit.h'
+  s.public_header_files = 'StompKit/StompKit.h', 'StompKit/SKSocket/SKSocket.h'
   s.requires_arc = true
   s.dependency 'CocoaAsyncSocket', '7.3.4'
   s.dependency 'SocketRocket', '0.3.1-beta2'

--- a/StompKit.xcodeproj/project.pbxproj
+++ b/StompKit.xcodeproj/project.pbxproj
@@ -13,6 +13,16 @@
 		1F5B42B31ACD8AF100FABE04 /* SKRawSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B42B01ACD8AF100FABE04 /* SKRawSocket.m */; };
 		1F5B42B61ACDA59500FABE04 /* SKSocketUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B42B51ACDA59500FABE04 /* SKSocketUtility.m */; };
 		1F5B42B71ACDA59500FABE04 /* SKSocketUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B42B51ACDA59500FABE04 /* SKSocketUtility.m */; };
+		1F8326881ACDC8EE000D3A09 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F8326871ACDC8EE000D3A09 /* main.m */; };
+		1F83268B1ACDC8EE000D3A09 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F83268A1ACDC8EE000D3A09 /* AppDelegate.m */; };
+		1F83268E1ACDC8EE000D3A09 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F83268D1ACDC8EE000D3A09 /* ViewController.m */; };
+		1F8326911ACDC8EE000D3A09 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1F83268F1ACDC8EE000D3A09 /* Main.storyboard */; };
+		1F8326931ACDC8EE000D3A09 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1F8326921ACDC8EE000D3A09 /* Images.xcassets */; };
+		1F8326961ACDC8EE000D3A09 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1F8326941ACDC8EE000D3A09 /* LaunchScreen.xib */; };
+		1F8326A91ACDC8FC000D3A09 /* libStompKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 932BA57818056C4B00A03257 /* libStompKit.a */; };
+		1F8326AD1ACDC98D000D3A09 /* libPods-CocoaAsyncSocket.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F8326AC1ACDC98D000D3A09 /* libPods-CocoaAsyncSocket.a */; };
+		1F8326AF1ACDC994000D3A09 /* libPods-SocketRocket.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F8326AE1ACDC994000D3A09 /* libPods-SocketRocket.a */; };
+		1F8326B11ACDC9AE000D3A09 /* libicucore.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F8326B01ACDC9AE000D3A09 /* libicucore.dylib */; };
 		6C24B5EB8E0343E483E53CA2 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37A4F2569A574CA6A0704DA6 /* libPods.a */; };
 		932BA57C18056C4B00A03257 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932BA57B18056C4B00A03257 /* Foundation.framework */; };
 		932BA58118056C4B00A03257 /* StompKit.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 932BA58018056C4B00A03257 /* StompKit.h */; };
@@ -57,6 +67,20 @@
 		1F5B42B11ACD8AF100FABE04 /* SKSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKSocket.h; sourceTree = "<group>"; };
 		1F5B42B41ACDA59500FABE04 /* SKSocketUtility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKSocketUtility.h; sourceTree = "<group>"; };
 		1F5B42B51ACDA59500FABE04 /* SKSocketUtility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SKSocketUtility.m; sourceTree = "<group>"; };
+		1F8326831ACDC8EE000D3A09 /* StompKitSandbox.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StompKitSandbox.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F8326861ACDC8EE000D3A09 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1F8326871ACDC8EE000D3A09 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		1F8326891ACDC8EE000D3A09 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		1F83268A1ACDC8EE000D3A09 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		1F83268C1ACDC8EE000D3A09 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		1F83268D1ACDC8EE000D3A09 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		1F8326901ACDC8EE000D3A09 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		1F8326921ACDC8EE000D3A09 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		1F8326951ACDC8EE000D3A09 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		1F8326AA1ACDC982000D3A09 /* libPods.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libPods.a; path = "Pods/../build/Debug-iphoneos/libPods.a"; sourceTree = "<group>"; };
+		1F8326AC1ACDC98D000D3A09 /* libPods-CocoaAsyncSocket.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libPods-CocoaAsyncSocket.a"; path = "Pods/../build/Debug-iphoneos/libPods-CocoaAsyncSocket.a"; sourceTree = "<group>"; };
+		1F8326AE1ACDC994000D3A09 /* libPods-SocketRocket.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libPods-SocketRocket.a"; path = "Pods/../build/Debug-iphoneos/libPods-SocketRocket.a"; sourceTree = "<group>"; };
+		1F8326B01ACDC9AE000D3A09 /* libicucore.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libicucore.dylib; path = usr/lib/libicucore.dylib; sourceTree = SDKROOT; };
 		37A4F2569A574CA6A0704DA6 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C55F3E01D49876D5B53EC05 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		591868DBFE214F55AB478DA7 /* libPods-StompKitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-StompKitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -81,6 +105,17 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1F8326801ACDC8EE000D3A09 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F8326B11ACDC9AE000D3A09 /* libicucore.dylib in Frameworks */,
+				1F8326AF1ACDC994000D3A09 /* libPods-SocketRocket.a in Frameworks */,
+				1F8326AD1ACDC98D000D3A09 /* libPods-CocoaAsyncSocket.a in Frameworks */,
+				1F8326A91ACDC8FC000D3A09 /* libStompKit.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		932BA57518056C4B00A03257 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -130,6 +165,30 @@
 			path = SKSocket;
 			sourceTree = "<group>";
 		};
+		1F8326841ACDC8EE000D3A09 /* StompKitSandbox */ = {
+			isa = PBXGroup;
+			children = (
+				1F8326891ACDC8EE000D3A09 /* AppDelegate.h */,
+				1F83268A1ACDC8EE000D3A09 /* AppDelegate.m */,
+				1F83268C1ACDC8EE000D3A09 /* ViewController.h */,
+				1F83268D1ACDC8EE000D3A09 /* ViewController.m */,
+				1F83268F1ACDC8EE000D3A09 /* Main.storyboard */,
+				1F8326921ACDC8EE000D3A09 /* Images.xcassets */,
+				1F8326941ACDC8EE000D3A09 /* LaunchScreen.xib */,
+				1F8326851ACDC8EE000D3A09 /* Supporting Files */,
+			);
+			path = StompKitSandbox;
+			sourceTree = "<group>";
+		};
+		1F8326851ACDC8EE000D3A09 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				1F8326861ACDC8EE000D3A09 /* Info.plist */,
+				1F8326871ACDC8EE000D3A09 /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 		932BA56F18056C4B00A03257 = {
 			isa = PBXGroup;
 			children = (
@@ -139,6 +198,7 @@
 				938827EE18056CA2009A1164 /* README.md */,
 				932BA57D18056C4B00A03257 /* StompKit */,
 				932BA59118056C4C00A03257 /* StompKitTests */,
+				1F8326841ACDC8EE000D3A09 /* StompKitSandbox */,
 				932BA57A18056C4B00A03257 /* Frameworks */,
 				932BA57918056C4B00A03257 /* Products */,
 				1C9C6CD9BF6E5DAF68ADBC0D /* Pods */,
@@ -150,6 +210,7 @@
 			children = (
 				932BA57818056C4B00A03257 /* libStompKit.a */,
 				932BA58818056C4C00A03257 /* StompKitTests.xctest */,
+				1F8326831ACDC8EE000D3A09 /* StompKitSandbox.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -157,6 +218,10 @@
 		932BA57A18056C4B00A03257 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1F8326B01ACDC9AE000D3A09 /* libicucore.dylib */,
+				1F8326AE1ACDC994000D3A09 /* libPods-SocketRocket.a */,
+				1F8326AC1ACDC98D000D3A09 /* libPods-CocoaAsyncSocket.a */,
+				1F8326AA1ACDC982000D3A09 /* libPods.a */,
 				932BA57B18056C4B00A03257 /* Foundation.framework */,
 				932BA58918056C4C00A03257 /* XCTest.framework */,
 				932BA58C18056C4C00A03257 /* UIKit.framework */,
@@ -198,6 +263,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		1F8326821ACDC8EE000D3A09 /* StompKitSandbox */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F8326A71ACDC8EE000D3A09 /* Build configuration list for PBXNativeTarget "StompKitSandbox" */;
+			buildPhases = (
+				1F83267F1ACDC8EE000D3A09 /* Sources */,
+				1F8326801ACDC8EE000D3A09 /* Frameworks */,
+				1F8326811ACDC8EE000D3A09 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StompKitSandbox;
+			productName = StompKitSandbox;
+			productReference = 1F8326831ACDC8EE000D3A09 /* StompKitSandbox.app */;
+			productType = "com.apple.product-type.application";
+		};
 		932BA57718056C4B00A03257 /* StompKit */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 932BA59B18056C4C00A03257 /* Build configuration list for PBXNativeTarget "StompKit" */;
@@ -245,6 +327,11 @@
 			attributes = {
 				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = "Jeff Mesnil";
+				TargetAttributes = {
+					1F8326821ACDC8EE000D3A09 = {
+						CreatedOnToolsVersion = 6.2;
+					};
+				};
 			};
 			buildConfigurationList = 932BA57318056C4B00A03257 /* Build configuration list for PBXProject "StompKit" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -252,6 +339,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 932BA56F18056C4B00A03257;
 			productRefGroup = 932BA57918056C4B00A03257 /* Products */;
@@ -260,11 +348,22 @@
 			targets = (
 				932BA57718056C4B00A03257 /* StompKit */,
 				932BA58718056C4C00A03257 /* StompKitTests */,
+				1F8326821ACDC8EE000D3A09 /* StompKitSandbox */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		1F8326811ACDC8EE000D3A09 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F8326911ACDC8EE000D3A09 /* Main.storyboard in Resources */,
+				1F8326961ACDC8EE000D3A09 /* LaunchScreen.xib in Resources */,
+				1F8326931ACDC8EE000D3A09 /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		932BA58618056C4C00A03257 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -339,6 +438,16 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1F83267F1ACDC8EE000D3A09 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F83268E1ACDC8EE000D3A09 /* ViewController.m in Sources */,
+				1F83268B1ACDC8EE000D3A09 /* AppDelegate.m in Sources */,
+				1F8326881ACDC8EE000D3A09 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		932BA57418056C4B00A03257 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -372,6 +481,22 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		1F83268F1ACDC8EE000D3A09 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				1F8326901ACDC8EE000D3A09 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		1F8326941ACDC8EE000D3A09 /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				1F8326951ACDC8EE000D3A09 /* Base */,
+			);
+			name = LaunchScreen.xib;
+			sourceTree = "<group>";
+		};
 		932BA59418056C4C00A03257 /* InfoPlist.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -383,6 +508,53 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		1F8326A31ACDC8EE000D3A09 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = StompKitSandbox/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1F8326A41ACDC8EE000D3A09 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = StompKitSandbox/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		932BA59918056C4C00A03257 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -416,6 +588,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "-all_load";
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -446,6 +619,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				OTHER_LDFLAGS = "-all_load";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -510,6 +684,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1F8326A71ACDC8EE000D3A09 /* Build configuration list for PBXNativeTarget "StompKitSandbox" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F8326A31ACDC8EE000D3A09 /* Debug */,
+				1F8326A41ACDC8EE000D3A09 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		932BA57318056C4B00A03257 /* Build configuration list for PBXProject "StompKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/StompKit.xcodeproj/project.pbxproj
+++ b/StompKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F5B42B21ACD8AF100FABE04 /* SKRawSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B42B01ACD8AF100FABE04 /* SKRawSocket.m */; };
+		1F5B42B31ACD8AF100FABE04 /* SKRawSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B42B01ACD8AF100FABE04 /* SKRawSocket.m */; };
 		6C24B5EB8E0343E483E53CA2 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37A4F2569A574CA6A0704DA6 /* libPods.a */; };
 		932BA57C18056C4B00A03257 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932BA57B18056C4B00A03257 /* Foundation.framework */; };
 		932BA58118056C4B00A03257 /* StompKit.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 932BA58018056C4B00A03257 /* StompKit.h */; };
@@ -44,6 +46,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1F5B42AF1ACD8AF100FABE04 /* SKRawSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKRawSocket.h; sourceTree = "<group>"; };
+		1F5B42B01ACD8AF100FABE04 /* SKRawSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SKRawSocket.m; sourceTree = "<group>"; };
+		1F5B42B11ACD8AF100FABE04 /* SKSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKSocket.h; sourceTree = "<group>"; };
 		37A4F2569A574CA6A0704DA6 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C55F3E01D49876D5B53EC05 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		591868DBFE214F55AB478DA7 /* libPods-StompKitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-StompKitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -103,6 +108,16 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		1F5B42AE1ACD8AF100FABE04 /* SKSocket */ = {
+			isa = PBXGroup;
+			children = (
+				1F5B42AF1ACD8AF100FABE04 /* SKRawSocket.h */,
+				1F5B42B01ACD8AF100FABE04 /* SKRawSocket.m */,
+				1F5B42B11ACD8AF100FABE04 /* SKSocket.h */,
+			);
+			path = SKSocket;
+			sourceTree = "<group>";
+		};
 		932BA56F18056C4B00A03257 = {
 			isa = PBXGroup;
 			children = (
@@ -144,6 +159,7 @@
 			children = (
 				932BA58018056C4B00A03257 /* StompKit.h */,
 				932BA58218056C4B00A03257 /* StompKit.m */,
+				1F5B42AE1ACD8AF100FABE04 /* SKSocket */,
 			);
 			path = StompKit;
 			sourceTree = "<group>";
@@ -316,6 +332,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				932BA58318056C4B00A03257 /* StompKit.m in Sources */,
+				1F5B42B21ACD8AF100FABE04 /* SKRawSocket.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -324,6 +341,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				932BA59818056C4C00A03257 /* StompKitTests.m in Sources */,
+				1F5B42B31ACD8AF100FABE04 /* SKRawSocket.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/StompKit.xcodeproj/project.pbxproj
+++ b/StompKit.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		1F5B42B21ACD8AF100FABE04 /* SKRawSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B42B01ACD8AF100FABE04 /* SKRawSocket.m */; };
 		1F5B42B31ACD8AF100FABE04 /* SKRawSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B42B01ACD8AF100FABE04 /* SKRawSocket.m */; };
+		1F5B42B61ACDA59500FABE04 /* SKSocketUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B42B51ACDA59500FABE04 /* SKSocketUtility.m */; };
+		1F5B42B71ACDA59500FABE04 /* SKSocketUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B42B51ACDA59500FABE04 /* SKSocketUtility.m */; };
 		6C24B5EB8E0343E483E53CA2 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37A4F2569A574CA6A0704DA6 /* libPods.a */; };
 		932BA57C18056C4B00A03257 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932BA57B18056C4B00A03257 /* Foundation.framework */; };
 		932BA58118056C4B00A03257 /* StompKit.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 932BA58018056C4B00A03257 /* StompKit.h */; };
@@ -49,6 +51,8 @@
 		1F5B42AF1ACD8AF100FABE04 /* SKRawSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKRawSocket.h; sourceTree = "<group>"; };
 		1F5B42B01ACD8AF100FABE04 /* SKRawSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SKRawSocket.m; sourceTree = "<group>"; };
 		1F5B42B11ACD8AF100FABE04 /* SKSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKSocket.h; sourceTree = "<group>"; };
+		1F5B42B41ACDA59500FABE04 /* SKSocketUtility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKSocketUtility.h; sourceTree = "<group>"; };
+		1F5B42B51ACDA59500FABE04 /* SKSocketUtility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SKSocketUtility.m; sourceTree = "<group>"; };
 		37A4F2569A574CA6A0704DA6 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C55F3E01D49876D5B53EC05 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		591868DBFE214F55AB478DA7 /* libPods-StompKitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-StompKitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -114,6 +118,8 @@
 				1F5B42AF1ACD8AF100FABE04 /* SKRawSocket.h */,
 				1F5B42B01ACD8AF100FABE04 /* SKRawSocket.m */,
 				1F5B42B11ACD8AF100FABE04 /* SKSocket.h */,
+				1F5B42B41ACDA59500FABE04 /* SKSocketUtility.h */,
+				1F5B42B51ACDA59500FABE04 /* SKSocketUtility.m */,
 			);
 			path = SKSocket;
 			sourceTree = "<group>";
@@ -332,6 +338,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				932BA58318056C4B00A03257 /* StompKit.m in Sources */,
+				1F5B42B61ACDA59500FABE04 /* SKSocketUtility.m in Sources */,
 				1F5B42B21ACD8AF100FABE04 /* SKRawSocket.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -341,6 +348,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				932BA59818056C4C00A03257 /* StompKitTests.m in Sources */,
+				1F5B42B71ACDA59500FABE04 /* SKSocketUtility.m in Sources */,
 				1F5B42B31ACD8AF100FABE04 /* SKRawSocket.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StompKit.xcodeproj/project.pbxproj
+++ b/StompKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F1632441ACDA8460047AE0C /* SKWebSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F1632431ACDA8460047AE0C /* SKWebSocket.m */; };
+		1F1632451ACDA8460047AE0C /* SKWebSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F1632431ACDA8460047AE0C /* SKWebSocket.m */; };
 		1F5B42B21ACD8AF100FABE04 /* SKRawSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B42B01ACD8AF100FABE04 /* SKRawSocket.m */; };
 		1F5B42B31ACD8AF100FABE04 /* SKRawSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B42B01ACD8AF100FABE04 /* SKRawSocket.m */; };
 		1F5B42B61ACDA59500FABE04 /* SKSocketUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5B42B51ACDA59500FABE04 /* SKSocketUtility.m */; };
@@ -48,6 +50,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1F1632421ACDA8460047AE0C /* SKWebSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKWebSocket.h; sourceTree = "<group>"; };
+		1F1632431ACDA8460047AE0C /* SKWebSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SKWebSocket.m; sourceTree = "<group>"; };
 		1F5B42AF1ACD8AF100FABE04 /* SKRawSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKRawSocket.h; sourceTree = "<group>"; };
 		1F5B42B01ACD8AF100FABE04 /* SKRawSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SKRawSocket.m; sourceTree = "<group>"; };
 		1F5B42B11ACD8AF100FABE04 /* SKSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKSocket.h; sourceTree = "<group>"; };
@@ -120,6 +124,8 @@
 				1F5B42B11ACD8AF100FABE04 /* SKSocket.h */,
 				1F5B42B41ACDA59500FABE04 /* SKSocketUtility.h */,
 				1F5B42B51ACDA59500FABE04 /* SKSocketUtility.m */,
+				1F1632421ACDA8460047AE0C /* SKWebSocket.h */,
+				1F1632431ACDA8460047AE0C /* SKWebSocket.m */,
 			);
 			path = SKSocket;
 			sourceTree = "<group>";
@@ -338,6 +344,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				932BA58318056C4B00A03257 /* StompKit.m in Sources */,
+				1F1632441ACDA8460047AE0C /* SKWebSocket.m in Sources */,
 				1F5B42B61ACDA59500FABE04 /* SKSocketUtility.m in Sources */,
 				1F5B42B21ACD8AF100FABE04 /* SKRawSocket.m in Sources */,
 			);
@@ -348,6 +355,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				932BA59818056C4C00A03257 /* StompKitTests.m in Sources */,
+				1F1632451ACDA8460047AE0C /* SKWebSocket.m in Sources */,
 				1F5B42B71ACDA59500FABE04 /* SKSocketUtility.m in Sources */,
 				1F5B42B31ACD8AF100FABE04 /* SKRawSocket.m in Sources */,
 			);

--- a/StompKit.xcodeproj/project.pbxproj
+++ b/StompKit.xcodeproj/project.pbxproj
@@ -45,7 +45,7 @@
 
 /* Begin PBXFileReference section */
 		37A4F2569A574CA6A0704DA6 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		44F558268B504F65BBF4384B /* Pods-StompKitTests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StompKitTests.xcconfig"; path = "Pods/Pods-StompKitTests.xcconfig"; sourceTree = "<group>"; };
+		4C55F3E01D49876D5B53EC05 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		591868DBFE214F55AB478DA7 /* libPods-StompKitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-StompKitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9320F3901816698700FF599F /* Podfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; };
 		9320F3911816698700FF599F /* StompKit.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = StompKit.podspec; sourceTree = "<group>"; };
@@ -62,7 +62,9 @@
 		938827ED18056CA2009A1164 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		938827EE18056CA2009A1164 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
 		938827F218057877009A1164 /* StompKitTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StompKitTests.h; sourceTree = "<group>"; };
-		BFE05B97D82D403E8462EDC5 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
+		C320AB3F98001F00C6279012 /* Pods-StompKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StompKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-StompKitTests/Pods-StompKitTests.release.xcconfig"; sourceTree = "<group>"; };
+		D2165909412B23156C9154D2 /* Pods-StompKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StompKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-StompKitTests/Pods-StompKitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		D4381A627E6D2C175D779A5C /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -90,6 +92,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1C9C6CD9BF6E5DAF68ADBC0D /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				4C55F3E01D49876D5B53EC05 /* Pods.debug.xcconfig */,
+				D4381A627E6D2C175D779A5C /* Pods.release.xcconfig */,
+				D2165909412B23156C9154D2 /* Pods-StompKitTests.debug.xcconfig */,
+				C320AB3F98001F00C6279012 /* Pods-StompKitTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		932BA56F18056C4B00A03257 = {
 			isa = PBXGroup;
 			children = (
@@ -101,8 +114,7 @@
 				932BA59118056C4C00A03257 /* StompKitTests */,
 				932BA57A18056C4B00A03257 /* Frameworks */,
 				932BA57918056C4B00A03257 /* Products */,
-				BFE05B97D82D403E8462EDC5 /* Pods.xcconfig */,
-				44F558268B504F65BBF4384B /* Pods-StompKitTests.xcconfig */,
+				1C9C6CD9BF6E5DAF68ADBC0D /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -203,7 +215,7 @@
 		932BA57018056C4B00A03257 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = "Jeff Mesnil";
 			};
 			buildConfigurationList = 932BA57318056C4B00A03257 /* Build configuration list for PBXProject "StompKit" */;
@@ -263,7 +275,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-StompKitTests-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-StompKitTests/Pods-StompKitTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F14EDA9ACA514E238C2E405D /* Check Pods Manifest.lock */ = {
@@ -293,7 +305,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -341,7 +353,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -379,7 +390,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -409,7 +419,7 @@
 		};
 		932BA59C18056C4C00A03257 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BFE05B97D82D403E8462EDC5 /* Pods.xcconfig */;
+			baseConfigurationReference = 4C55F3E01D49876D5B53EC05 /* Pods.debug.xcconfig */;
 			buildSettings = {
 				DSTROOT = /tmp/StompKit.dst;
 				OTHER_LDFLAGS = "-ObjC";
@@ -420,7 +430,7 @@
 		};
 		932BA59D18056C4C00A03257 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BFE05B97D82D403E8462EDC5 /* Pods.xcconfig */;
+			baseConfigurationReference = D4381A627E6D2C175D779A5C /* Pods.release.xcconfig */;
 			buildSettings = {
 				DSTROOT = /tmp/StompKit.dst;
 				OTHER_LDFLAGS = "-ObjC";
@@ -431,9 +441,8 @@
 		};
 		932BA59F18056C4C00A03257 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 44F558268B504F65BBF4384B /* Pods-StompKitTests.xcconfig */;
+			baseConfigurationReference = D2165909412B23156C9154D2 /* Pods-StompKitTests.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -451,9 +460,8 @@
 		};
 		932BA5A018056C4C00A03257 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 44F558268B504F65BBF4384B /* Pods-StompKitTests.xcconfig */;
+			baseConfigurationReference = C320AB3F98001F00C6279012 /* Pods-StompKitTests.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",

--- a/StompKit.xcodeproj/xcshareddata/xcschemes/StompKit.xcscheme
+++ b/StompKit.xcodeproj/xcshareddata/xcschemes/StompKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0500"
+   LastUpgradeVersion = "0620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -49,6 +49,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "932BA57718056C4B00A03257"
+            BuildableName = "libStompKit.a"
+            BlueprintName = "StompKit"
+            ReferencedContainer = "container:StompKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/StompKit/SKSocket/SKRawSocket.h
+++ b/StompKit/SKSocket/SKRawSocket.h
@@ -1,0 +1,19 @@
+//
+//  SKRawSocket.h
+//  StompKit
+//
+//  Created by Travis Bowers on 4/2/15.
+//  Copyright (c) 2015 Jeff Mesnil. All rights reserved.
+//
+
+#ifndef StompKit_SKRawSocket_h
+#define StompKit_SKRawSocket_h
+
+#import "SKSocket.h"
+
+@interface SKRawSocket : NSObject <SKSocket>
+{
+}
+@end
+
+#endif

--- a/StompKit/SKSocket/SKRawSocket.m
+++ b/StompKit/SKSocket/SKRawSocket.m
@@ -1,0 +1,85 @@
+//
+//  SKRawSocket.m
+//  StompKit
+//
+//  Created by Travis Bowers on 4/2/15.
+//  Copyright (c) 2015 Jeff Mesnil. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "SKRawSocket.h"
+#import "GCDAsyncSocket.h"
+
+@interface SKRawSocket()
+@property (nonatomic, weak) id <SKSocketDelegate> delegate;
+@property (nonatomic, retain) GCDAsyncSocket *socket;
+@end
+
+@implementation SKRawSocket
+
+// synthesize properties
+@synthesize delegate;
+@synthesize socket;
+
+- (id)initWithDelegate:(id)aDelegate delegateQueue:(dispatch_queue_t)dq {
+    if((self = [super init])) {
+        if (aDelegate != nil) {
+            self.delegate = aDelegate;
+            
+            // initialize our socket
+            self.socket = [[GCDAsyncSocket alloc] initWithDelegate:self delegateQueue:dq];
+        }
+    }
+    
+    return self;
+}
+
+- (BOOL)connectToHost:(NSString*)host onPort:(uint16_t)port error:(NSError **)errPtr {
+    return [socket connectToHost:host onPort:port error:errPtr];
+}
+
+- (BOOL)isDisconnected {
+    return [socket isDisconnected];
+}
+
+- (void)writeData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag {
+    [socket writeData:data withTimeout:timeout tag:tag];
+}
+
+- (void)readDataToData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag {
+    [socket readDataToData:data withTimeout:timeout tag:tag];
+
+}
+
+- (void)disconnectAfterReadingAndWriting {
+    [socket disconnectAfterReadingAndWriting];
+}
+
+#pragma mark -
+#pragma mark GCDAsyncSocketDelegate
+
+- (void)socket:(GCDAsyncSocket *)sock didReadData:(NSData *)data withTag:(long)tag {
+    if (self.delegate != nil) {
+        [delegate socket:(SKSocket*)self didReadData:data withTag:tag];
+    }
+}
+
+- (void)socket:(GCDAsyncSocket *)sock didReadPartialDataOfLength:(NSUInteger)partialLength tag:(long)tag {
+    if (self.delegate != nil) {
+        [delegate socket:(SKSocket*)self didReadPartialDataOfLength:partialLength tag:tag];
+    }
+}
+
+- (void)socket:(GCDAsyncSocket *)sock didConnectToHost:(NSString *)host port:(uint16_t)port {
+    if (self.delegate != nil) {
+        [delegate socket:(SKSocket*)self didConnectToHost:host port:port];
+    }
+}
+
+- (void)socketDidDisconnect:(GCDAsyncSocket *)sock withError:(NSError *)err {
+    if (self.delegate != nil) {
+        [delegate socketDidDisconnect:(SKSocket*)self withError:err];
+    }
+}
+
+@end

--- a/StompKit/SKSocket/SKRawSocket.m
+++ b/StompKit/SKSocket/SKRawSocket.m
@@ -42,12 +42,12 @@
     return [socket isDisconnected];
 }
 
-- (void)writeData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag {
-    [socket writeData:data withTimeout:timeout tag:tag];
+- (void)writeData:(NSData *)data withTimeout:(NSTimeInterval)timeout {
+    [socket writeData:data withTimeout:timeout tag:123];
 }
 
-- (void)readDataToData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag {
-    [socket readDataToData:data withTimeout:timeout tag:tag];
+- (void)readDataToData:(NSData *)data withTimeout:(NSTimeInterval)timeout {
+    [socket readDataToData:data withTimeout:timeout tag:123];
     
 }
 
@@ -60,13 +60,13 @@
 
 - (void)socket:(GCDAsyncSocket *)sock didReadData:(NSData *)data withTag:(long)tag {
     if (self.delegate != nil) {
-        [delegate socket:(SKSocket*)self didReadData:data withTag:tag];
+        [delegate socket:(SKSocket*)self didReadData:data];
     }
 }
 
 - (void)socket:(GCDAsyncSocket *)sock didReadPartialDataOfLength:(NSUInteger)partialLength tag:(long)tag {
     if (self.delegate != nil) {
-        [delegate socket:(SKSocket*)self didReadPartialDataOfLength:partialLength tag:tag];
+        [delegate socket:(SKSocket*)self didReadPartialDataOfLength:partialLength];
     }
 }
 

--- a/StompKit/SKSocket/SKRawSocket.m
+++ b/StompKit/SKSocket/SKRawSocket.m
@@ -10,7 +10,7 @@
 #import "SKRawSocket.h"
 #import "GCDAsyncSocket.h"
 
-@interface SKRawSocket()
+@interface SKRawSocket() <GCDAsyncSocketDelegate>
 @property (nonatomic, weak) id <SKSocketDelegate> delegate;
 @property (nonatomic, retain) GCDAsyncSocket *socket;
 @end

--- a/StompKit/SKSocket/SKRawSocket.m
+++ b/StompKit/SKSocket/SKRawSocket.m
@@ -60,7 +60,7 @@
 
 - (void)socket:(GCDAsyncSocket *)sock didReadData:(NSData *)data withTag:(long)tag {
     if (self.delegate != nil) {
-        [delegate socket:(SKSocket*)self didReadData:data];
+        [delegate socket:(SKSocket*)self didReadDataWithData:data];
     }
 }
 

--- a/StompKit/SKSocket/SKRawSocket.m
+++ b/StompKit/SKSocket/SKRawSocket.m
@@ -48,7 +48,7 @@
 
 - (void)readDataToData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag {
     [socket readDataToData:data withTimeout:timeout tag:tag];
-
+    
 }
 
 - (void)disconnectAfterReadingAndWriting {

--- a/StompKit/SKSocket/SKSocket.h
+++ b/StompKit/SKSocket/SKSocket.h
@@ -17,7 +17,8 @@
 // SKSocket delegate interface
 @protocol SKSocketDelegate <NSObject>
 @optional
-- (void)socket:(SKSocket *)sock didReadData:(NSData *)data;
+- (void)socket:(SKSocket *)sock didReadDataWithData:(NSData *)data;
+- (void)socket:(SKSocket *)sock didReadDataWithString:(NSString *)data;
 - (void)socket:(SKSocket *)sock didReadPartialDataOfLength:(NSUInteger)partialLength;
 - (void)socket:(SKSocket *)sock didConnectToHost:(NSString *)host port:(uint16_t)port;
 - (void)socketDidDisconnect:(SKSocket *)sock withError:(NSError *)err;

--- a/StompKit/SKSocket/SKSocket.h
+++ b/StompKit/SKSocket/SKSocket.h
@@ -9,9 +9,12 @@
 #ifndef StompKit_SKSocket_h
 #define StompKit_SKSocket_h
 
+#import "SKSocketUtility.h"
+
 // forward declare
 @class SKSocket;
 
+// SKSocket delegate interface
 @protocol SKSocketDelegate <NSObject>
 @optional
 - (void)socket:(SKSocket *)sock didReadData:(NSData *)data withTag:(long)tag;
@@ -21,6 +24,8 @@
 @end
 
 
+
+// SKSocket abstract interface
 @protocol SKSocket <NSObject>
 - (id)initWithDelegate:(id)aDelegate delegateQueue:(dispatch_queue_t)dq;
 - (BOOL)connectToHost:(NSString*)host onPort:(uint16_t)port error:(NSError **)errPtr;

--- a/StompKit/SKSocket/SKSocket.h
+++ b/StompKit/SKSocket/SKSocket.h
@@ -17,8 +17,8 @@
 // SKSocket delegate interface
 @protocol SKSocketDelegate <NSObject>
 @optional
-- (void)socket:(SKSocket *)sock didReadData:(NSData *)data withTag:(long)tag;
-- (void)socket:(SKSocket *)sock didReadPartialDataOfLength:(NSUInteger)partialLength tag:(long)tag;
+- (void)socket:(SKSocket *)sock didReadData:(NSData *)data;
+- (void)socket:(SKSocket *)sock didReadPartialDataOfLength:(NSUInteger)partialLength;
 - (void)socket:(SKSocket *)sock didConnectToHost:(NSString *)host port:(uint16_t)port;
 - (void)socketDidDisconnect:(SKSocket *)sock withError:(NSError *)err;
 @end
@@ -30,8 +30,8 @@
 - (id)initWithDelegate:(id)aDelegate delegateQueue:(dispatch_queue_t)dq;
 - (BOOL)connectToHost:(NSString*)host onPort:(uint16_t)port error:(NSError **)errPtr;
 - (BOOL)isDisconnected;
-- (void)writeData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag;
-- (void)readDataToData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag;
+- (void)writeData:(NSData *)data withTimeout:(NSTimeInterval)timeout;
+- (void)readDataToData:(NSData *)data withTimeout:(NSTimeInterval)timeout;
 - (void)disconnectAfterReadingAndWriting;
 
 @end

--- a/StompKit/SKSocket/SKSocket.h
+++ b/StompKit/SKSocket/SKSocket.h
@@ -1,0 +1,34 @@
+//
+//  SKSocket.h
+//  StompKit
+//
+//  Created by Travis Bowers on 4/2/15.
+//  Copyright (c) 2015 Jeff Mesnil. All rights reserved.
+//
+
+#ifndef StompKit_SKSocket_h
+#define StompKit_SKSocket_h
+
+// forward declare
+@class SKSocket;
+
+@protocol SKSocketDelegate <NSObject>
+@optional
+- (void)socket:(SKSocket *)sock didReadData:(NSData *)data withTag:(long)tag;
+- (void)socket:(SKSocket *)sock didReadPartialDataOfLength:(NSUInteger)partialLength tag:(long)tag;
+- (void)socket:(SKSocket *)sock didConnectToHost:(NSString *)host port:(uint16_t)port;
+- (void)socketDidDisconnect:(SKSocket *)sock withError:(NSError *)err;
+@end
+
+
+@protocol SKSocket <NSObject>
+- (id)initWithDelegate:(id)aDelegate delegateQueue:(dispatch_queue_t)dq;
+- (BOOL)connectToHost:(NSString*)host onPort:(uint16_t)port error:(NSError **)errPtr;
+- (BOOL)isDisconnected;
+- (void)writeData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag;
+- (void)readDataToData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag;
+- (void)disconnectAfterReadingAndWriting;
+
+@end
+
+#endif

--- a/StompKit/SKSocket/SKSocketUtility.h
+++ b/StompKit/SKSocket/SKSocketUtility.h
@@ -1,0 +1,14 @@
+//
+//  SKSocketUtility.h
+//  StompKit
+//
+//  Created by Travis Bowers on 4/2/15.
+//  Copyright (c) 2015 Jeff Mesnil. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SKSocketUtility : NSObject
++ (NSData*)zeroData;
++ (NSData*)lineFeedData;
+@end

--- a/StompKit/SKSocket/SKSocketUtility.m
+++ b/StompKit/SKSocket/SKSocketUtility.m
@@ -1,0 +1,21 @@
+//
+//  SKSocketUtility.m
+//  StompKit
+//
+//  Created by Travis Bowers on 4/2/15.
+//  Copyright (c) 2015 Jeff Mesnil. All rights reserved.
+//
+
+#import "SKSocketUtility.h"
+
+@implementation SKSocketUtility
+
++ (NSData*)zeroData {
+    return [NSData dataWithBytes:"" length:1];
+}
+
++ (NSData*)lineFeedData {
+    return [NSData dataWithBytes:"\x0A" length:1];
+}
+
+@end

--- a/StompKit/SKSocket/SKWebSocket.h
+++ b/StompKit/SKSocket/SKWebSocket.h
@@ -1,18 +1,16 @@
 //
-//  SKRawSocket.h
+//  SKWebSocket.h
 //  StompKit
 //
 //  Created by Travis Bowers on 4/2/15.
 //  Copyright (c) 2015 Jeff Mesnil. All rights reserved.
 //
 
-#ifndef StompKit_SKRawSocket_h
-#define StompKit_SKRawSocket_h
-
+#import <Foundation/Foundation.h>
 #import "SKSocket.h"
 
-@interface SKRawSocket : NSObject <SKSocket> {
+extern NSString *const SKWebSocketErrorDomain;
+
+@interface SKWebSocket : NSObject <SKSocket> {
 }
 @end
-
-#endif

--- a/StompKit/SKSocket/SKWebSocket.m
+++ b/StompKit/SKSocket/SKWebSocket.m
@@ -56,8 +56,7 @@ NSString *const SKWebSocketErrorDomain = @"SKWebSocketErrorDomain";
 }
 
 - (void)disconnectAfterReadingAndWriting {
-    // not supported
-    //[socket disconnectAfterReadingAndWriting];
+    [socket close];
 }
 
 #pragma mark -

--- a/StompKit/SKSocket/SKWebSocket.m
+++ b/StompKit/SKSocket/SKWebSocket.m
@@ -47,7 +47,8 @@ NSString *const SKWebSocketErrorDomain = @"SKWebSocketErrorDomain";
 }
 
 - (void)writeData:(NSData *)data withTimeout:(NSTimeInterval)timeout {
-    [socket send:data];
+    // convert data to string and send
+    [socket send:[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]];
 }
 
 - (void)readDataToData:(NSData *)data withTimeout:(NSTimeInterval)timeout {
@@ -62,7 +63,7 @@ NSString *const SKWebSocketErrorDomain = @"SKWebSocketErrorDomain";
 #pragma mark -
 #pragma mark SRWebSocketDelegate
 - (void)webSocket:(SRWebSocket *)webSocket didReceiveMessage:(id)message {
-    [delegate socket:(SKSocket*)self didReadData:message];
+    [delegate socket:(SKSocket*)self didReadDataWithString:message];
 }
 
 - (void)webSocketDidOpen:(SRWebSocket *)webSocket {

--- a/StompKit/SKSocket/SKWebSocket.m
+++ b/StompKit/SKSocket/SKWebSocket.m
@@ -46,11 +46,11 @@ NSString *const SKWebSocketErrorDomain = @"SKWebSocketErrorDomain";
     return !self.connected;
 }
 
-- (void)writeData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag {
+- (void)writeData:(NSData *)data withTimeout:(NSTimeInterval)timeout {
     [socket send:data];
 }
 
-- (void)readDataToData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag {
+- (void)readDataToData:(NSData *)data withTimeout:(NSTimeInterval)timeout {
     // not supported
     //[socket readDataToData:data withTimeout:timeout tag:tag];
 }
@@ -63,7 +63,7 @@ NSString *const SKWebSocketErrorDomain = @"SKWebSocketErrorDomain";
 #pragma mark -
 #pragma mark SRWebSocketDelegate
 - (void)webSocket:(SRWebSocket *)webSocket didReceiveMessage:(id)message {
-    [delegate socket:(SKSocket*)self didReadData:message withTag:123];
+    [delegate socket:(SKSocket*)self didReadData:message];
 }
 
 - (void)webSocketDidOpen:(SRWebSocket *)webSocket {

--- a/StompKit/SKSocket/SKWebSocket.m
+++ b/StompKit/SKSocket/SKWebSocket.m
@@ -1,0 +1,94 @@
+//
+//  SKWebSocket.m
+//  StompKit
+//
+//  Created by Travis Bowers on 4/2/15.
+//  Copyright (c) 2015 Jeff Mesnil. All rights reserved.
+//
+
+#import "SKWebSocket.h"
+#import "GCDAsyncSocket.h"
+#import "SRWebSocket.h"
+
+NSString *const SKWebSocketErrorDomain = @"SKWebSocketErrorDomain";
+
+@interface SKWebSocket() <SRWebSocketDelegate>
+@property (nonatomic, weak) id <SKSocketDelegate> delegate;
+@property (nonatomic, retain) SRWebSocket *socket;
+@property (nonatomic, assign) BOOL connected;
+@end
+
+@implementation SKWebSocket
+
+// synthesize properties
+@synthesize delegate;
+@synthesize socket;
+
+- (id)initWithDelegate:(id)aDelegate delegateQueue:(dispatch_queue_t)dq {
+    if((self = [super init])) {
+        if (aDelegate != nil) {
+            self.delegate = aDelegate;
+            self.connected = NO;
+        }
+    }
+    
+    return self;
+}
+
+- (BOOL)connectToHost:(NSString*)host onPort:(uint16_t)port error:(NSError **)errPtr {
+    self.socket = [[SRWebSocket alloc] initWithURL:[NSURL URLWithString:host]];
+    self.socket.delegate = self;
+    [self.socket open];
+    return YES;
+}
+
+- (BOOL)isDisconnected {
+    return !self.connected;
+}
+
+- (void)writeData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag {
+    [socket send:data];
+}
+
+- (void)readDataToData:(NSData *)data withTimeout:(NSTimeInterval)timeout tag:(long)tag {
+    // not supported
+    //[socket readDataToData:data withTimeout:timeout tag:tag];
+}
+
+- (void)disconnectAfterReadingAndWriting {
+    // not supported
+    //[socket disconnectAfterReadingAndWriting];
+}
+
+#pragma mark -
+#pragma mark SRWebSocketDelegate
+- (void)webSocket:(SRWebSocket *)webSocket didReceiveMessage:(id)message {
+    [delegate socket:(SKSocket*)self didReadData:message withTag:123];
+}
+
+- (void)webSocketDidOpen:(SRWebSocket *)webSocket {
+    self.connected = YES;
+    [delegate socket:(SKSocket*)self didConnectToHost:self.socket.url.absoluteString port:80];
+}
+
+- (void)webSocket:(SRWebSocket *)webSocket didFailWithError:(NSError *)error {
+    self.connected = NO;
+    [delegate socketDidDisconnect:(SKSocket*)self withError:error];
+}
+
+- (void)webSocket:(SRWebSocket *)webSocket didCloseWithCode:(NSInteger)code reason:(NSString *)reason wasClean:(BOOL)wasClean {
+    self.connected = NO;
+    
+    NSError *error = nil;
+    
+    if (wasClean == NO) {
+        NSDictionary *userInfo = @{NSLocalizedDescriptionKey: @"Socket did close",
+                                   NSLocalizedFailureReasonErrorKey: reason
+                                   };
+        error = [NSError errorWithDomain:SKWebSocketErrorDomain code:-57 userInfo:userInfo];
+    }
+    
+    [delegate socketDidDisconnect:(SKSocket*)self withError:error];
+}
+
+@end

--- a/StompKit/StompKit.h
+++ b/StompKit/StompKit.h
@@ -91,6 +91,7 @@ typedef void (^STOMPMessageHandler)(STOMPMessage *message);
 - (id)initWithHost:(NSString *)theHost
 			  port:(NSUInteger)thePort;
 
+- (void)connectWithCompletionHandler:(void (^)(STOMPFrame *connectedFrame, NSError *error))completionHandler;
 - (void)connectWithLogin:(NSString *)login
                 passcode:(NSString *)passcode
        completionHandler:(void (^)(STOMPFrame *connectedFrame, NSError *error))completionHandler;

--- a/StompKit/StompKit.h
+++ b/StompKit/StompKit.h
@@ -88,8 +88,8 @@ typedef void (^STOMPMessageHandler)(STOMPMessage *message);
 @property (nonatomic, copy) void (^errorHandler)(NSError *error);
 @property (nonatomic, assign) BOOL connected;
 
-- (id)initWithHost:(NSString *)theHost
-			  port:(NSUInteger)thePort;
+- (id)initWithHost:(NSString *)theHost;
+- (id)initWithHost:(NSString *)theHost andPort:(NSUInteger)thePort;
 
 - (void)connectWithCompletionHandler:(void (^)(STOMPFrame *connectedFrame, NSError *error))completionHandler;
 - (void)connectWithLogin:(NSString *)login

--- a/StompKit/StompKit.m
+++ b/StompKit/StompKit.m
@@ -8,6 +8,7 @@
 
 #import "StompKit.h"
 #import "GCDAsyncSocket.h"
+#import "SKSocket.h"
 
 #define kDefaultTimeout 5
 #define kVersion1_2 @"1.2"

--- a/StompKit/StompKit.m
+++ b/StompKit/StompKit.m
@@ -442,7 +442,7 @@ CFAbsoluteTime serverActivity;
     STOMPFrame *frame = [[STOMPFrame alloc] initWithCommand:command headers:headers body:body];
     LogDebug(@">>> %@", frame);
     NSData *data = [frame toData];
-    [self.socket writeData:data withTimeout:kDefaultTimeout tag:123];
+    [self.socket writeData:data withTimeout:kDefaultTimeout];
 }
 
 - (void)sendPing:(NSTimer *)timer  {
@@ -450,7 +450,7 @@ CFAbsoluteTime serverActivity;
         return;
     }
 
-    [self.socket writeData:[SKSocketUtility lineFeedData] withTimeout:kDefaultTimeout tag:123];
+    [self.socket writeData:[SKSocketUtility lineFeedData] withTimeout:kDefaultTimeout];
     LogDebug(@">>> PING");
 }
 
@@ -550,20 +550,20 @@ CFAbsoluteTime serverActivity;
 }
 
 - (void)readFrame {
-	[[self socket] readDataToData:[SKSocketUtility zeroData] withTimeout:-1 tag:0];
+	[[self socket] readDataToData:[SKSocketUtility zeroData] withTimeout:-1];
 }
 
 #pragma mark -
 #pragma mark SKSocketDelegate
 
-- (void)socket:(SKSocket *)sock didReadData:(NSData *)data withTag:(long)tag {
+- (void)socket:(SKSocket *)sock didReadData:(NSData *)data {
     serverActivity = CFAbsoluteTimeGetCurrent();
     STOMPFrame *frame = [STOMPFrame STOMPFrameFromData:data];
     [self receivedFrame:frame];
     [self readFrame];
 }
 
-- (void)socket:(SKSocket *)sock didReadPartialDataOfLength:(NSUInteger)partialLength tag:(long)tag {
+- (void)socket:(SKSocket *)sock didReadPartialDataOfLength:(NSUInteger)partialLength {
     LogDebug(@"<<< PONG");
     serverActivity = CFAbsoluteTimeGetCurrent();
 }

--- a/StompKit/StompKit.m
+++ b/StompKit/StompKit.m
@@ -311,8 +311,11 @@ CFAbsoluteTime serverActivity;
 #pragma mark -
 #pragma mark Public API
 
-- (id)initWithHost:(NSString *)aHost
-              port:(NSUInteger)aPort {
+- (id)initWithHost:(NSString *)theHost {
+    return [self initWithHost:theHost andPort:0];
+}
+
+- (id)initWithHost:(NSString *)aHost andPort:(NSUInteger)aPort {
     if(self = [super init]) {
         //self.socket = [[SKRawSocket alloc] initWithDelegate:self delegateQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)];
         self.socket = [[SKWebSocket alloc] initWithDelegate:self delegateQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)];

--- a/StompKit/StompKit.m
+++ b/StompKit/StompKit.m
@@ -317,9 +317,14 @@ CFAbsoluteTime serverActivity;
 
 - (id)initWithHost:(NSString *)aHost andPort:(NSUInteger)aPort {
     if(self = [super init]) {
-        //self.socket = [[SKRawSocket alloc] initWithDelegate:self delegateQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)];
-        self.socket = [[SKWebSocket alloc] initWithDelegate:self delegateQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)];
-
+        // rough comparision now to determine whether or not use websocket
+        if ([aHost hasPrefix:@"ws://"]) {
+            self.socket = [[SKWebSocket alloc] initWithDelegate:self delegateQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)];
+        }
+        else {
+            self.socket = [[SKRawSocket alloc] initWithDelegate:self delegateQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)];
+        }
+        
         self.host = aHost;
         self.port = aPort;
         idGenerator = 0;

--- a/StompKitSandbox/AppDelegate.h
+++ b/StompKitSandbox/AppDelegate.h
@@ -1,0 +1,17 @@
+//
+//  AppDelegate.h
+//  StompKitSandbox
+//
+//  Created by Travis Bowers on 4/2/15.
+//  Copyright (c) 2015 Jeff Mesnil. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+
+@end
+

--- a/StompKitSandbox/AppDelegate.m
+++ b/StompKitSandbox/AppDelegate.m
@@ -1,0 +1,45 @@
+//
+//  AppDelegate.m
+//  StompKitSandbox
+//
+//  Created by Travis Bowers on 4/2/15.
+//  Copyright (c) 2015 Jeff Mesnil. All rights reserved.
+//
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    return YES;
+}
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+}
+
+@end

--- a/StompKitSandbox/Base.lproj/LaunchScreen.xib
+++ b/StompKitSandbox/Base.lproj/LaunchScreen.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 Jeff Mesnil. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                    <rect key="frame" x="20" y="439" width="441" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="StompKitSandbox" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                    <rect key="frame" x="20" y="140" width="441" height="43"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="bottom" multiplier="1/3" constant="1" id="5cJ-9S-tgC"/>
+                <constraint firstAttribute="centerX" secondItem="kId-c2-rCX" secondAttribute="centerX" id="Koa-jz-hwk"/>
+                <constraint firstAttribute="bottom" secondItem="8ie-xW-0ye" secondAttribute="bottom" constant="20" id="Kzo-t9-V3l"/>
+                <constraint firstItem="8ie-xW-0ye" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="MfP-vx-nX0"/>
+                <constraint firstAttribute="centerX" secondItem="8ie-xW-0ye" secondAttribute="centerX" id="ZEH-qu-HZ9"/>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="fvb-Df-36g"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="548" y="455"/>
+        </view>
+    </objects>
+</document>

--- a/StompKitSandbox/Base.lproj/Main.storyboard
+++ b/StompKitSandbox/Base.lproj/Main.storyboard
@@ -25,6 +25,24 @@
                                     <action selector="connectButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="KJ2-Jc-0wP"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dZV-ki-bIU">
+                                <rect key="frame" x="96" y="20" width="89" height="30"/>
+                                <state key="normal" title="Disconnect">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="disconnectButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Kqb-zG-mkF"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ae8-Jt-6bK">
+                                <rect key="frame" x="193" y="20" width="72" height="30"/>
+                                <state key="normal" title="Send">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="sendButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ngF-w2-Qju"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>

--- a/StompKitSandbox/Base.lproj/Main.storyboard
+++ b/StompKitSandbox/Base.lproj/Main.storyboard
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hin-KP-wp1">
+                                <rect key="frame" x="16" y="20" width="72" height="30"/>
+                                <state key="normal" title="Connect">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="connectButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="KJ2-Jc-0wP"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/StompKitSandbox/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/StompKitSandbox/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/StompKitSandbox/Info.plist
+++ b/StompKitSandbox/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.tbowers.stompkit.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/StompKitSandbox/ViewController.h
+++ b/StompKitSandbox/ViewController.h
@@ -1,0 +1,15 @@
+//
+//  ViewController.h
+//  StompKitSandbox
+//
+//  Created by Travis Bowers on 4/2/15.
+//  Copyright (c) 2015 Jeff Mesnil. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+
+@end
+

--- a/StompKitSandbox/ViewController.m
+++ b/StompKitSandbox/ViewController.m
@@ -28,7 +28,7 @@
 
 - (IBAction)connectButtonPressed:(id)sender {
     // create the client
-    client = [[STOMPClient alloc] initWithHost:@"ws://le3.liveexpertdev.net:61614/stomp" port:0];
+    client = [[STOMPClient alloc] initWithHost:@"ws://localhost:61614/stomp"];
     // connect to the broker
     [client connectWithCompletionHandler:^(STOMPFrame *_, NSError *error) {
         if (error) {
@@ -37,7 +37,7 @@
         }
         
         // send a message
-        [client sendTo:@"/queue/myqueue" body:@"Hello, iOS!"];
+        [client sendTo:@"/queue/bowers" body:@"Hello, iOS!"];
         // and disconnect
         [client disconnect];
     }];

--- a/StompKitSandbox/ViewController.m
+++ b/StompKitSandbox/ViewController.m
@@ -10,10 +10,11 @@
 #import "StompKit.h"
 
 @interface ViewController ()
-
+@property (nonatomic, strong) STOMPClient *client;
 @end
 
 @implementation ViewController
+@synthesize client;
 
 - (void)viewDidLoad {
     [super viewDidLoad];
@@ -27,11 +28,10 @@
 
 - (IBAction)connectButtonPressed:(id)sender {
     // create the client
-    STOMPClient *client = [[STOMPClient alloc] initWithHost:@"localhost"
-                                                       port:61613];
+    client = [[STOMPClient alloc] initWithHost:@"ws://le3.liveexpertdev.net:61614/stomp" port:0];
     // connect to the broker
-    [client connectWithLogin:@"mylogin"
-                    passcode:@"mypassword"
+    [client connectWithLogin:@"admin"
+                    passcode:@"admin"
            completionHandler:^(STOMPFrame *_, NSError *error) {
                if (error) {
                    NSLog(@"%@", error);
@@ -43,6 +43,17 @@
                // and disconnect
                [client disconnect];
            }];
+}
+
+- (IBAction)disconnectButtonPressed:(id)sender {
+    if (client != nil) {
+        [client disconnect];
+    }
+}
+
+- (IBAction)sendButtonPressed:(id)sender {
+    // send a message
+    [client sendTo:@"/queue/travis" body:@"Hello, iOS!"];
 }
 
 @end

--- a/StompKitSandbox/ViewController.m
+++ b/StompKitSandbox/ViewController.m
@@ -30,19 +30,17 @@
     // create the client
     client = [[STOMPClient alloc] initWithHost:@"ws://le3.liveexpertdev.net:61614/stomp" port:0];
     // connect to the broker
-    [client connectWithLogin:@"admin"
-                    passcode:@"admin"
-           completionHandler:^(STOMPFrame *_, NSError *error) {
-               if (error) {
-                   NSLog(@"%@", error);
-                   return;
-               }
-               
-               // send a message
-               [client sendTo:@"/queue/myqueue" body:@"Hello, iOS!"];
-               // and disconnect
-               [client disconnect];
-           }];
+    [client connectWithCompletionHandler:^(STOMPFrame *_, NSError *error) {
+        if (error) {
+            NSLog(@"%@", error);
+            return;
+        }
+        
+        // send a message
+        [client sendTo:@"/queue/myqueue" body:@"Hello, iOS!"];
+        // and disconnect
+        [client disconnect];
+    }];
 }
 
 - (IBAction)disconnectButtonPressed:(id)sender {
@@ -53,7 +51,7 @@
 
 - (IBAction)sendButtonPressed:(id)sender {
     // send a message
-    [client sendTo:@"/queue/travis" body:@"Hello, iOS!"];
+    [client sendTo:@"/queue/myqueue" body:@"Hello, iOS!"];
 }
 
 @end

--- a/StompKitSandbox/ViewController.m
+++ b/StompKitSandbox/ViewController.m
@@ -1,0 +1,48 @@
+//
+//  ViewController.m
+//  StompKitSandbox
+//
+//  Created by Travis Bowers on 4/2/15.
+//  Copyright (c) 2015 Jeff Mesnil. All rights reserved.
+//
+
+#import "ViewController.h"
+#import "StompKit.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view, typically from a nib.
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+- (IBAction)connectButtonPressed:(id)sender {
+    // create the client
+    STOMPClient *client = [[STOMPClient alloc] initWithHost:@"localhost"
+                                                       port:61613];
+    // connect to the broker
+    [client connectWithLogin:@"mylogin"
+                    passcode:@"mypassword"
+           completionHandler:^(STOMPFrame *_, NSError *error) {
+               if (error) {
+                   NSLog(@"%@", error);
+                   return;
+               }
+               
+               // send a message
+               [client sendTo:@"/queue/myqueue" body:@"Hello, iOS!"];
+               // and disconnect
+               [client disconnect];
+           }];
+}
+
+@end

--- a/StompKitSandbox/main.m
+++ b/StompKitSandbox/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  StompKitSandbox
+//
+//  Created by Travis Bowers on 4/2/15.
+//  Copyright (c) 2015 Jeff Mesnil. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/StompKitTests/StompKitTests.m
+++ b/StompKitTests/StompKitTests.m
@@ -30,7 +30,7 @@
     [super setUp];
 
     self.client = [[STOMPClient alloc] initWithHost:HOST
-                                               port:PORT];
+                                               andPort:PORT];
 }
 
 - (void)tearDown
@@ -43,7 +43,7 @@
 
     dispatch_semaphore_t errorReceived = dispatch_semaphore_create(0);
 
-    STOMPClient *otherClient = [[STOMPClient alloc] initWithHost:@"invalid host" port:61613];
+    STOMPClient *otherClient = [[STOMPClient alloc] initWithHost:@"invalid host" andPort:61613];
     [otherClient connectWithLogin:LOGIN
                          passcode:PASSCODE
                 completionHandler:^(STOMPFrame *connectedFrame, NSError *error) {


### PR DESCRIPTION
The purpose of this fork was to add web socket support. In doing so, I abstracted the raw socket usage under a common interface. I then added the RocketSocket web socket library and implemented the same interface. The strategy used is based on the host string provided (e.g. "ws://").

As part of my testing, I added a very basic single view iOS app to exercise the usage. It appears to be working fine at least with my AMQ server.

I don't believe I've done anything to regress the current library's functionality so I wanted to submit it back for possible merging. Otherwise, I'll continue to maintain my fork for WebSocket usage.
